### PR TITLE
Update with new airfoil link

### DIFF
--- a/data/download_airfoils.sh
+++ b/data/download_airfoils.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 echo downloading...
-wget http://m-selig.ae.illinois.edu/ads/archives/coord_seligFmt.tar.gz
+wget http://m-selig.ae.illinois.edu/ads/archives/coord_seligFmt.zip
 
 echo unpacking...
-tar xzf ./coord_seligFmt.tar.gz 
+unzip ./coord_seligFmt.zip
 
 mkdir ./airfoil_database
 mkdir ./airfoil_database_test
@@ -40,7 +40,7 @@ rm naca1.dat
 
 cd ..
 rm -fr ./coord_seligFmt/
-rm ./coord_seligFmt.tar.gz 
+rm ./coord_seligFmt.zip
 
 echo done!
 exit 1


### PR DESCRIPTION
Fixes #11

From the [dataset website](https://m-selig.ae.illinois.edu/ads_history.html):
> 5/27/21 - 5/30/21 - Updated zipfile archive in "Selig" format: [coord_seligFmt.zip.](https://m-selig.ae.illinois.edu/ads/archives/coord_seligFmt.zip) This file contains all airfoils (approx 1,600). Removed the previous companion .tar.gz file.

Note: there are new additions in the dataset and some other changes, so the other parts of the script may not consider the new airfoils